### PR TITLE
feat(portal): otp login logic

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -8,7 +8,11 @@
     "dev": "npm run build && nodemon --watch src --ext js,scss,html,njk --exec \"npm run start\"",
     "build": "node src/util/build.js",
     "start": "node src/server.js",
-    "test": "node --test"
+    "test": "npx jest",
+    "test:web": "npx jest src/app/web",
+    "test:api": "npx jest src/app/api",
+    "test:nocov": "npx jest --coverage=false",
+    "test:util": "npx jest src/app/util"
   },
   "license": "MIT",
   "dependencies": {

--- a/apps/portal/src/app/otp-controller.js
+++ b/apps/portal/src/app/otp-controller.js
@@ -1,0 +1,54 @@
+// OTP Controller: handles OTP-related routes
+const otpService = require('./otp-service');
+
+/**
+ * Request OTP controller
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ */
+async function requestOtp(req, res) {
+	const { email } = req.body;
+	if (!email) {
+		return res.status(400).json({ error: 'Email is required.' });
+	}
+	try {
+		await otpService.createAndSendOtp(email);
+		return res.status(200).json({ message: 'OTP sent.' });
+	} catch {
+		return res.status(500).json({ error: 'Failed to send OTP.' });
+	}
+}
+
+/**
+ * Validate OTP controller
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ */
+async function validateOtp(req, res) {
+	const { email, otp } = req.body;
+	if (!email || !otp) {
+		return res.status(400).json({ error: 'Email and OTP are required.' });
+	}
+	try {
+		const result = await otpService.validateOtp(email, otp);
+		if (result.valid) {
+			return res.status(200).json({ message: 'OTP valid.' });
+		}
+		// Map reasons to error messages
+		const errorMap = {
+			not_found: 'No OTP found for this email.',
+			used: 'OTP has already been used.',
+			expired: 'OTP has expired.',
+			invalid: 'OTP is invalid.',
+			too_many_attempts: 'Too many incorrect attempts. Please request a new code.'
+		};
+		return res.status(400).json({ error: errorMap[result.reason] || 'OTP validation failed.' });
+	} catch {
+		return res.status(500).json({ error: 'Failed to validate OTP.' });
+	}
+}
+
+module.exports = {
+	requestOtp,
+	validateOtp
+};

--- a/apps/portal/src/app/otp-service.js
+++ b/apps/portal/src/app/otp-service.js
@@ -1,0 +1,109 @@
+// OTP Service for generating, sending, and validating one-time passwords (OTPs)
+
+const prisma = require('./prisma');
+const govNotifyClient = require('../../../../packages/lib/govnotify/gov-notify-client');
+
+const OTP_LENGTH = 5;
+const OTP_EXPIRY_MINUTES = 30;
+const MAX_ATTEMPTS = 4;
+
+// Helper to generate a 5-letter uppercase OTP
+function generateOtp() {
+	const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+	let otp = '';
+	for (let i = 0; i < OTP_LENGTH; i++) {
+		otp += letters.charAt(Math.floor(Math.random() * letters.length));
+	}
+	return otp;
+}
+
+// Save OTP to database
+async function saveOtp(email, otp, expiresAt) {
+	// Remove any existing unused/expired OTPs for this email
+	await prisma.otp.deleteMany({
+		where: {
+			email,
+			used: false,
+			expiresAt: { lt: new Date() }
+		}
+	});
+	// Create new OTP record
+	await prisma.otp.create({
+		data: {
+			email,
+			code: otp,
+			expiresAt,
+			used: false,
+			attempts: 0
+		}
+	});
+}
+
+// Retrieve OTP record by email
+async function getOtpRecord(email) {
+	return prisma.otp.findFirst({
+		where: { email },
+		orderBy: { createdAt: 'desc' }
+	});
+}
+
+// Mark OTP as used
+async function markOtpUsed(email) {
+	await prisma.otp.updateMany({
+		where: { email, used: false },
+		data: { used: true }
+	});
+}
+
+// Increment OTP attempt count
+async function incrementOtpAttempts(email) {
+	await prisma.otp.updateMany({
+		where: { email, used: false },
+		data: { attempts: { increment: 1 } }
+	});
+}
+
+// Send OTP email using GovNotify
+async function sendOtpEmail(email, otp) {
+	return govNotifyClient.sendEmail({
+		emailAddress: email,
+		templateId: 'YOUR_OTP_TEMPLATE_ID', // i need to add templeate id here
+		personalisation: { code: otp }
+	});
+}
+
+// Create and send OTP
+async function createAndSendOtp(email) {
+	const otp = generateOtp();
+	const expiresAt = new Date(Date.now() + OTP_EXPIRY_MINUTES * 60000);
+	await saveOtp(email, otp, expiresAt);
+	await sendOtpEmail(email, otp);
+	return otp;
+}
+
+// Validate OTP
+async function validateOtp(email, otp) {
+	const record = await getOtpRecord(email);
+	if (!record) return { valid: false, reason: 'not_found' };
+	if (record.used) return { valid: false, reason: 'used' };
+	if (record.attempts >= MAX_ATTEMPTS) return { valid: false, reason: 'too_many_attempts' };
+	if (new Date() > new Date(record.expiresAt)) return { valid: false, reason: 'expired' };
+	if (record.code !== otp) {
+		await incrementOtpAttempts(email);
+		if (record.attempts + 1 >= MAX_ATTEMPTS) {
+			return { valid: false, reason: 'too_many_attempts' };
+		}
+		return { valid: false, reason: 'invalid' };
+	}
+	await markOtpUsed(email);
+	return { valid: true };
+}
+
+module.exports = {
+	generateOtp,
+	createAndSendOtp,
+	validateOtp,
+	OTP_LENGTH,
+	OTP_EXPIRY_MINUTES,
+	MAX_ATTEMPTS
+};

--- a/apps/portal/src/app/prisma.js
+++ b/apps/portal/src/app/prisma.js
@@ -1,0 +1,4 @@
+// Prisma client singleton for OTP service
+const { PrismaClient } = require('../../../packages/database/src/client');
+const prisma = new PrismaClient();
+module.exports = prisma;

--- a/apps/portal/src/app/router.js
+++ b/apps/portal/src/app/router.js
@@ -3,6 +3,7 @@ import { createMonitoringRoutes } from '@pins/dco-portal-lib/controllers/monitor
 import { createRoutes as appRoutes } from './views/home/index.js';
 import { createErrorRoutes } from './views/static/error/index.js';
 import { cacheNoCacheMiddleware } from '@pins/dco-portal-lib/middleware/cache.js';
+import otpController from './otp-controller.js';
 
 /**
  * @param {import('#service').App1Service} service
@@ -21,6 +22,8 @@ export function buildRouter(service) {
 
 	router.use('/', appRoutes(service));
 	router.use('/error', createErrorRoutes(service));
+	router.post('/request-otp', otpController.requestOtp);
+	router.post('/validate-otp', otpController.validateOtp);
 
 	return router;
 }

--- a/apps/portal/src/app/util/otp-service.test.js
+++ b/apps/portal/src/app/util/otp-service.test.js
@@ -1,0 +1,130 @@
+/* eslint-env jest */
+const otpService = require('../otp-service.js');
+
+// Mock dependencies
+jest.mock('../../../../../packages/lib/govnotify/gov-notify-client', () => ({
+	sendEmail: jest.fn(() => Promise.resolve('email sent'))
+}));
+
+// Mock Prisma client
+jest.mock('../prisma', () => ({
+	otp: {
+		create: jest.fn(),
+		findFirst: jest.fn(),
+		updateMany: jest.fn(),
+		deleteMany: jest.fn()
+	}
+}));
+const prisma = require('../prisma');
+
+// ...existing test code (same as before) ...
+
+describe('OTP Service', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('generateOtp', () => {
+		it('should generate a 5-letter uppercase OTP', () => {
+			const otp = otpService.generateOtp();
+			expect(otp).toHaveLength(5);
+			expect(otp).toMatch(/^[A-Z]{5}$/);
+		});
+	});
+
+	describe('createAndSendOtp', () => {
+		it('should generate and send an OTP', async () => {
+			prisma.otp.deleteMany.mockResolvedValue();
+			prisma.otp.create.mockResolvedValue();
+			const email = 'test@example.com';
+			const otp = await otpService.createAndSendOtp(email);
+			expect(otp).toHaveLength(5);
+			expect(prisma.otp.create).toHaveBeenCalledWith(
+				expect.objectContaining({
+					data: expect.objectContaining({
+						email,
+						code: expect.any(String),
+						expiresAt: expect.any(Date),
+						used: false,
+						attempts: 0
+					})
+				})
+			);
+		});
+	});
+
+	describe('validateOtp', () => {
+		it('should return not_found if no record', async () => {
+			prisma.otp.findFirst.mockResolvedValue(null);
+			const result = await otpService.validateOtp('a@b.com', 'ABCDE');
+			expect(result).toEqual({ valid: false, reason: 'not_found' });
+		});
+
+		it('should return used if OTP already used', async () => {
+			prisma.otp.findFirst.mockResolvedValue({ used: true });
+			const result = await otpService.validateOtp('a@b.com', 'ABCDE');
+			expect(result).toEqual({ valid: false, reason: 'used' });
+		});
+
+		it('should return expired if OTP expired', async () => {
+			prisma.otp.findFirst.mockResolvedValue({
+				used: false,
+				attempts: 0,
+				expiresAt: new Date(Date.now() - 1000),
+				code: 'ABCDE'
+			});
+			const result = await otpService.validateOtp('a@b.com', 'ABCDE');
+			expect(result).toEqual({ valid: false, reason: 'expired' });
+		});
+
+		it('should return too_many_attempts if attempts >= 4', async () => {
+			prisma.otp.findFirst.mockResolvedValue({
+				used: false,
+				attempts: 4,
+				expiresAt: new Date(Date.now() + 10000),
+				code: 'ABCDE'
+			});
+			const result = await otpService.validateOtp('a@b.com', 'ABCDE');
+			expect(result).toEqual({ valid: false, reason: 'too_many_attempts' });
+		});
+
+		it('should return invalid and increment attempts if OTP does not match', async () => {
+			prisma.otp.findFirst.mockResolvedValue({
+				used: false,
+				attempts: 1,
+				expiresAt: new Date(Date.now() + 10000),
+				code: 'ABCDE'
+			});
+			prisma.otp.updateMany.mockResolvedValue();
+			const result = await otpService.validateOtp('a@b.com', 'ZZZZZ');
+			expect(result).toEqual({ valid: false, reason: 'invalid' });
+			expect(prisma.otp.updateMany).toHaveBeenCalled();
+		});
+
+		it('should return too_many_attempts if OTP does not match and attempts reach 4', async () => {
+			prisma.otp.findFirst.mockResolvedValue({
+				used: false,
+				attempts: 3,
+				expiresAt: new Date(Date.now() + 10000),
+				code: 'ABCDE'
+			});
+			prisma.otp.updateMany.mockResolvedValue();
+			const result = await otpService.validateOtp('a@b.com', 'ZZZZZ');
+			expect(result).toEqual({ valid: false, reason: 'too_many_attempts' });
+			expect(prisma.otp.updateMany).toHaveBeenCalled();
+		});
+
+		it('should return valid and mark OTP as used if OTP matches', async () => {
+			prisma.otp.findFirst.mockResolvedValue({
+				used: false,
+				attempts: 0,
+				expiresAt: new Date(Date.now() + 10000),
+				code: 'ABCDE'
+			});
+			prisma.otp.updateMany.mockResolvedValue();
+			const result = await otpService.validateOtp('a@b.com', 'ABCDE');
+			expect(result).toEqual({ valid: true });
+			expect(prisma.otp.updateMany).toHaveBeenCalled();
+		});
+	});
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,9 +13,19 @@ export default [
 			ecmaVersion: 2025,
 			sourceType: 'module',
 			globals: {
-				...globals.node
+				...globals.node,
+				...globals.jest
 			}
 		}
 	},
-	eslintConfigPrettier
+	eslintConfigPrettier,
+
+	{
+		files: ['**/*.test.js', '**/*.spec.js'],
+		languageOptions: {
+			globals: {
+				...globals.jest
+			}
+		}
+	}
 ];

--- a/packages/database/src/schema.prisma
+++ b/packages/database/src/schema.prisma
@@ -18,3 +18,16 @@ datasource db {
 // this is because these IDs may be used in URLs and it makes them harder to guess
 // while we don't rely on that for security, it adds an extra layer
 // not everything needs this, but easier to make them all consistent and the increase in size (vs int) is negligible
+
+model Otp {
+  id        String   @id @default(uuid())
+  email     String
+  code      String // 5-letter OTP
+  expiresAt DateTime
+  used      Boolean  @default(false)
+  attempts  Int      @default(0)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([email])
+}


### PR DESCRIPTION
## Describe your changes - 
Implemented OTP (one-time password) login via email.
Generates a random 5-letter uppercase OTP and sends it to the user’s email.
Stores OTP with a 30-minute expiry and enforces single-use.
Validates OTP on submission, handling expired, reused, incorrect, and too-many-attempts scenarios.
Moved OTP logic to a dedicated controller and updated tests as per project structure.

## Issue ticket number and link-  DCOP-15  --  https://pins-ds.atlassian.net/browse/DCOP-15 
