### PR TITLE
fix(infrastructure): turn on public access temporarily to allow priva…

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -22,12 +22,12 @@ resource "azurerm_key_vault" "main" {
   soft_delete_retention_days    = 7
   purge_protection_enabled      = true
   rbac_authorization_enabled    = true
-  public_network_access_enabled = false
+  public_network_access_enabled = true
   sku_name                      = "standard"
 
   network_acls {
     bypass         = "AzureServices"
-    default_action = "Deny"
+    default_action = "Allow"
   }
 
   tags = local.tags


### PR DESCRIPTION
- This PR/branch should **not** be merged into main.
- When the next Infra CD PROD is run - it will fail. This is because Key Vault will deny public access and therefore the private endpoint can't be finished. A classic chicken and egg scenario 🐔🥚
- If you simply run this branch(not main) in ADO it will turn on public access (you may not have permissions in portal itself, hence why there is a branch here just for PROD).
- You may be able to raise your access level in portal by adding the relevant group on the Key Vault resource such as <service_name>-contributor as key vault contributor. Your non-su account could be in this group and not your SU if that is another reason why you may not be able to edit in portal.
- You could run this pipeline first and then main after if you did not want to see the failed pipeline

1. Pipeline Fails with Public network access is disabled 
2. Run this branch -> pipeline is successful
3. Run main -> pipeline is good (check your KV resource networking in portal to see access is also Disabled
4. Delete this PR and Branch