### PR TITLE
fix(database): add newspaper notices to required tables

### DIFF
--- a/packages/database/src/migrations/20260721130500_add_newspaper_notices_reference_data/migration.sql
+++ b/packages/database/src/migrations/20260721130500_add_newspaper_notices_reference_data/migration.sql
@@ -1,0 +1,51 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+IF NOT EXISTS (
+    SELECT *
+    FROM dbo.DocumentCategory
+    WHERE id = 'newspaper-notices'
+)
+BEGIN
+INSERT INTO dbo.DocumentCategory (
+    id,
+    displayName
+)
+VALUES (
+           'newspaper-notices',
+           'Newspaper notices'
+       );
+END;
+
+IF NOT EXISTS (
+    SELECT *
+    FROM dbo.DocumentSubCategory
+    WHERE id = 'newspaper-notices'
+)
+BEGIN
+INSERT INTO dbo.DocumentSubCategory (
+    id,
+    displayName,
+    categoryId
+)
+VALUES (
+           'newspaper-notices',
+           'Newspaper notices',
+           'newspaper-notices'
+       );
+END;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+ROLLBACK TRAN;
+END;
+
+THROW;
+
+END CATCH;


### PR DESCRIPTION
## Describe your changes
Fixing a bug where a user is not able to upload a document to the 'newspaper notices' section following [this PR](https://github.com/Planning-Inspectorate/applications-dco-portal/pull/531)

The PR added the new document category and document sub category to the data-static.ts file but when going through the dev and test environments the pipelines do not run a seed to add the changes to those tables

This PR adds a migration script to add the new data to the associated tables

## Issue ticket number and link
[ticket 693](https://pins-ds.atlassian.net/jira/software/c/projects/IDAS/boards/1034?selectedIssue=IDAS-693)
